### PR TITLE
Fix Space Invaders Coin input missing

### DIFF
--- a/src/burner/libretro/bind_map.cpp
+++ b/src/burner/libretro/bind_map.cpp
@@ -20,6 +20,10 @@ unsigned init_bind_map(key_map bind_map[], bool gamepad_controls, bool newgen_co
 
    /* Universal controls */
 
+   bind_map[PTR_INCR].bii_name = "Coin";
+   bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_SELECT;
+   bind_map[PTR_INCR].nCode[1] = 0;
+
    bind_map[PTR_INCR].bii_name = "Coin 1";
    bind_map[PTR_INCR].nCode[0] = RETRO_DEVICE_ID_JOYPAD_SELECT;
    bind_map[PTR_INCR].nCode[1] = 0;

--- a/src/burner/libretro/bind_map.h
+++ b/src/burner/libretro/bind_map.h
@@ -1,7 +1,7 @@
 #ifndef _BIND_MAP_H_
 #define _BIND_MAP_H_
 
-#define BIND_MAP_COUNT 304
+#define BIND_MAP_COUNT 305
 #define PTR_INCR ((incr++ % 3 == 2) ? counter++ : counter)
 
 // Ref GamcPlayer() in ../gamc.cpp


### PR DESCRIPTION
Related issue #81

The input with the name 'Coin' was missing in the bind_map.
This will fix the following games:
- Freeze (freeze)
- Korosuke Roller (korosuke)
- Sky Army (skyarmy)
- Space Invaders (invaders)
- Space Invaders (TV Version) (sitv)
- Super Casino (sucasino)
- Super Triv (striv)
- The Glob (Pac-Man hardware) (theglobp)
- Van-Van Car (vanvan)