### PR TITLE
Quick fix for the fallback to load rom with wrong crc

### DIFF
--- a/src/burner/libretro/libretro.cpp
+++ b/src/burner/libretro/libretro.cpp
@@ -920,7 +920,7 @@ static bool open_archive()
 
          if (index < 0)
          {
-            int index = find_rom_by_name(rom_name, list, count);
+            index = find_rom_by_name(rom_name, list, count);
             bad_crc = true;
          }
 


### PR DESCRIPTION
Related issue #95 

Very small fix, to be able to load rom with wrong crc but with good name.
Now it's possible to load an hacked version of the Universe Bios ;-)