### PR TITLE
Revert commit af5f0cb for Asterix to boot

### DIFF
--- a/src/burn/drv/konami/d_asterix.cpp
+++ b/src/burn/drv/konami/d_asterix.cpp
@@ -57,7 +57,6 @@ static struct BurnInputInfo AsterixInputList[] = {
 	{"P1 Button 2",		BIT_DIGITAL,	DrvJoy1 + 5,	"p1 fire 2"	},
 
 	{"P2 Coin",		BIT_DIGITAL,	DrvJoy1 + 9,	"p2 coin"	},
-	{"P2 Start",		BIT_DIGITAL,	DrvJoy2 + 7,	"p2 start"	},
 	{"P2 Up",		BIT_DIGITAL,	DrvJoy2 + 2,	"p2 up"		},
 	{"P2 Down",		BIT_DIGITAL,	DrvJoy2 + 3,	"p2 down"	},
 	{"P2 Left",		BIT_DIGITAL,	DrvJoy2 + 0,	"p2 left"	},


### PR DESCRIPTION
The commit https://github.com/libretro/fbalpha/commit/af5f0cbfe57f86bba7e90e37faba9b6d399d3d32 doesn't let the game to boot. It should have fixed P2 not being able to enter the game, but mapping Start button for P2 breaks the game.
Until a solution can be found, let the game work for P1 only.

Message warning says:
"Test switch is still on please release it or repair"