### PR TITLE
backport 

### DIFF
--- a/src/burn/drv/cps3/cps3run.cpp
+++ b/src/burn/drv/cps3/cps3run.cpp
@@ -2087,12 +2087,14 @@ INT32 cps3Scan(INT32 nAction, INT32 *pnMin)
 		ba.nAddress = 0;
 		ba.szName	= "Palette";
 		BurnAcb(&ba);
-
+#ifndef __LIBRETRO__
 		ba.Data		= RamCRam;
 		ba.nLen		= 0x0800000;
 		ba.nAddress = 0;
 		ba.szName	= "Sprite ROM";
 		BurnAcb(&ba);
+#endif
+
 
 /*		// so huge. need not backup it while NOCD
 		// otherwize, need backup gfx also


### PR DESCRIPTION
https://github.com/libretro/fbalpha2012/commit/8cedcfafc6f6f66987555f91833b1103a441fdae

This makes savestates a lot faster (enough for CPS3 netplay with rewind) at the expense of messed up savestate colors or sprite data on initial load.

Probably should be a core option.