### PR TITLE
hiscore.dat retrieved from SYSTEM_DIRECTORY/fba/

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Samples should be put under SYSTEM_DIRECTORY/fba/samples
 
 ## hiscore.dat
 
-Move hiscore.dat from /metadata/ to your SAVE_DIRECTORY
+Move hiscore.dat from /metadata/ to /SYSTEM_DIRECTORY/fba/
 
 ## Raspberry Pi 2 users
 

--- a/src/burn/hiscore.cpp
+++ b/src/burn/hiscore.cpp
@@ -367,7 +367,7 @@ void HiscoreInit()
 #else
 	char slash = '/';
 #endif
-	snprintf(szDatFilename, sizeof(szDatFilename), "%s%chiscore.dat", g_save_dir, slash);
+	snprintf(szDatFilename, sizeof(szDatFilename), "%s%cfba%chiscore.dat", g_system_dir, slash, slash);
 #else
  	_stprintf(szDatFilename, _T("%shiscore.dat"), szAppHiscorePath);
 #endif


### PR DESCRIPTION
Previously was SAVE_DIRECTORY. Normally any supporting files that are not user-generated are retrieved from SYSTEM_DIRECTORY. This matches https://github.com/libretro/mame2003-libretro and I believe other MAME cores with hiscore support. The generated .hi files are still kept in SAVE_DIRECTORY