### PR TITLE
More conformant file open implementation

### DIFF
--- a/src/burner/libretro/libretro-common/streams/file_stream_transforms.c
+++ b/src/burner/libretro/libretro-common/streams/file_stream_transforms.c
@@ -32,21 +32,34 @@ RFILE* rfopen(const char *path, const char *mode)
    unsigned int retro_mode = RETRO_VFS_FILE_ACCESS_READ;
    bool position_to_end    = false;
 
-   if (strstr(mode, "w"))
-      retro_mode = RETRO_VFS_FILE_ACCESS_WRITE;
 
-   if (strstr(mode, "a"))
+   if (strstr(mode, "r"))
    {
-      retro_mode = RETRO_VFS_FILE_ACCESS_READ_WRITE | 
+      retro_mode = RETRO_VFS_FILE_ACCESS_READ;
+      if (strstr(mode, "+"))
+      {
+         retro_mode = RETRO_VFS_FILE_ACCESS_READ_WRITE | 
+            RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING;
+      }
+   }
+   else if (strstr(mode, "w"))
+   {
+      retro_mode = RETRO_VFS_FILE_ACCESS_WRITE;
+      if (strstr(mode, "+"))
+      {
+         retro_mode = RETRO_VFS_FILE_ACCESS_READ_WRITE;
+      }
+   }
+   else if (strstr(mode, "a"))
+   {
+      retro_mode = RETRO_VFS_FILE_ACCESS_WRITE | 
          RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING;
       position_to_end = true;
-   }
-
-   if (strstr(mode, "+"))
-   {
-      retro_mode = RETRO_VFS_FILE_ACCESS_READ_WRITE;
-      if (strstr(mode, "r"))
-         retro_mode = retro_mode & RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING;
+      if (strstr(mode, "+"))
+      {
+         retro_mode = RETRO_VFS_FILE_ACCESS_READ_WRITE | 
+            RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING;
+      }
    }
 
    output = filestream_open(path, retro_mode,

--- a/src/burner/libretro/libretro-common/vfs/vfs_implementation.c
+++ b/src/burner/libretro/libretro-common/vfs/vfs_implementation.c
@@ -75,11 +75,6 @@
 
 #endif
 
-#define MODE_STR_READ "r"
-#define MODE_STR_READ_UNBUF "rb"
-#define MODE_STR_WRITE_UNBUF "wb"
-#define MODE_STR_WRITE_PLUS "w+"
-
 #ifdef RARCH_INTERNAL
 #ifndef VFS_FRONTEND
 #define VFS_FRONTEND
@@ -208,36 +203,48 @@ libretro_vfs_implementation_file *retro_vfs_file_open_impl(const char *path, uns
    switch (mode)
    {
       case RETRO_VFS_FILE_ACCESS_READ:
-         if ((stream->hints & RFILE_HINT_UNBUFFERED) == 0)
-            mode_str = MODE_STR_READ_UNBUF;
-         /* No "else" here */
+         mode_str = "rb";
+
          flags    = O_RDONLY;
-         break;
-      case RETRO_VFS_FILE_ACCESS_WRITE:
-         if ((stream->hints & RFILE_HINT_UNBUFFERED) == 0)
-            mode_str = MODE_STR_WRITE_UNBUF;
-         else
-         {
-            flags    = O_WRONLY | O_CREAT | O_TRUNC;
-#ifndef _WIN32
-            flags   |=  S_IRUSR | S_IWUSR;
-#endif
-         }
-         break;
-      case RETRO_VFS_FILE_ACCESS_READ_WRITE:
-         if ((stream->hints & RFILE_HINT_UNBUFFERED) == 0)
-            mode_str = MODE_STR_WRITE_PLUS;
-         else
-         {
-            flags    = O_RDWR;
 #ifdef _WIN32
-            flags   |= O_BINARY;
+         flags   |= O_BINARY;
 #endif
-         }
          break;
-      case RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING:
-         /* TODO/FIXME - implement */
-         goto error;
+
+      case RETRO_VFS_FILE_ACCESS_WRITE:
+         mode_str = "wb";
+
+         flags    = O_WRONLY | O_CREAT | O_TRUNC;
+#ifndef _WIN32
+         flags   |= S_IRUSR | S_IWUSR;
+#else
+         flags   |= O_BINARY;
+#endif
+         break;
+
+      case RETRO_VFS_FILE_ACCESS_READ_WRITE:
+         mode_str = "w+b";
+
+         flags    = O_RDWR | O_CREAT | O_TRUNC;
+#ifndef _WIN32
+         flags   |= S_IRUSR | S_IWUSR;
+#else
+         flags   |= O_BINARY;
+#endif
+         break;
+
+      case RETRO_VFS_FILE_ACCESS_WRITE | RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING:
+      case RETRO_VFS_FILE_ACCESS_READ_WRITE | RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING:
+         mode_str = "r+b";
+
+         flags    = O_RDWR;
+#ifndef _WIN32
+         flags   |= S_IRUSR | S_IWUSR;
+#else
+         flags   |= O_BINARY;
+#endif
+         break;
+         
       default:
          goto error;
    }


### PR DESCRIPTION
@twinaphex @Alcaro 
Modified `rfopen` and vfs fallback path to be more conformant to the VFS spec and handle `RETRO_VFS_FILE_ACCESS_UPDATE_EXISTING`, as you requested.
Given the sensitive nature of the code in question, review would be appreciated.

I have tested the core against the Retroarch build available for download on the homepage, which should have no VFS support. All games I tried (NeoGeo, CPS2, CPS3 + dkong with hiscore.dat) work.