### PR TITLE
MSVC compilation fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/libretro/fbalpha.svg?branch=master)](https://travis-ci.org/libretro/fbalpha)
+[![Build status](https://ci.appveyor.com/api/projects/status/bdj5xf7t3kgbk1p7/branch/master?svg=true)](https://ci.appveyor.com/project/bparker06/fbalpha/branch/master)
+
 # fba-libretro
 
 ## Roms

--- a/src/burn/burn.h
+++ b/src/burn/burn.h
@@ -24,6 +24,13 @@ extern TCHAR szAppSamplesPath[MAX_PATH];
 extern TCHAR szAppBlendPath[MAX_PATH];
 extern TCHAR szAppEEPROMPath[MAX_PATH];
 
+// Fix for MSVC' issues with offsetof
+#ifdef _MSC_VER
+#undef offsetof
+#define offsetof(s, m) ((size_t)&(((s *)0)->m))
+//#define offsetof(s,m) ((size_t)(((s*)0)->m))
+#endif
+
 // Macro to determine the size of a struct up to a member (included)
 #define STRUCT_SIZE_HELPER(type, member) offsetof(type, member) + sizeof(((type*)0)->member)
 

--- a/src/burn/burn.h
+++ b/src/burn/burn.h
@@ -28,7 +28,6 @@ extern TCHAR szAppEEPROMPath[MAX_PATH];
 #ifdef _MSC_VER
 #undef offsetof
 #define offsetof(s, m) ((size_t)&(((s *)0)->m))
-//#define offsetof(s,m) ((size_t)(((s*)0)->m))
 #endif
 
 // Macro to determine the size of a struct up to a member (included)

--- a/src/burn/driver.h
+++ b/src/burn/driver.h
@@ -38,7 +38,6 @@ __extension__ typedef long long				INT64;
 #ifdef _MSC_VER
 #undef offsetof
 #define offsetof(s, m) ((size_t)&(((s *)0)->m))
-//#define offsetof(s,m) ((size_t)(((s*)0)->m))
 #endif
 
 // Macro to determine the size of a struct up to a member (included)

--- a/src/burn/driver.h
+++ b/src/burn/driver.h
@@ -34,6 +34,13 @@ __extension__ typedef unsigned long long	UINT64;
 __extension__ typedef long long				INT64;
 #endif
 
+// Fix for MSVC' issues with offsetof
+#ifdef _MSC_VER
+#undef offsetof
+#define offsetof(s, m) ((size_t)&(((s *)0)->m))
+//#define offsetof(s,m) ((size_t)(((s*)0)->m))
+#endif
+
 // Macro to determine the size of a struct up to a member (included)
 #define STRUCT_SIZE_HELPER(type, member) offsetof(type, member) + sizeof(((type*)0)->member)
 


### PR DESCRIPTION
Not the most elegant solution, fixed builds on MSVC using the [canonical `offsetof` implementation](https://en.wikipedia.org/wiki/Offsetof).

Also added build status badges