### PR TITLE
Allow build on Solaris target

### DIFF
--- a/makefile.libretro
+++ b/makefile.libretro
@@ -75,6 +75,11 @@ ifneq (,$(findstring unix,$(platform)))
    SHARED := -shared -Wl,-no-undefined -Wl,--version-script=$(VERSION_SCRIPT)
    ENDIANNESS_DEFINES := -DLSB_FIRST
 
+   ifneq (,$(findstring SunOS,$(shell uname -s)))
+   CC := gcc
+   SHARED := -shared 
+   endif
+
    # Raspberry Pi
    ifneq (,$(findstring rpi2,$(platform)))
       PLATFORM_DEFINES := -marm -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -ffast-math

--- a/src/cpu/nec/nec.cpp
+++ b/src/cpu/nec/nec.cpp
@@ -238,7 +238,7 @@ int nec_reset()
 	nec_state->vector = 0xff; //default vector
 
 	Sreg(PS) = 0xffff;
-	Sreg(SS) = 0;
+	Sreg(SS_) = 0;
 	Sreg(DS0) = 0;
 	Sreg(DS1) = 0;
 
@@ -544,13 +544,13 @@ static CPU_SET_INFO( nec )
 			break;
 		case CPUINFO_INT_REGISTER + NEC_IP:				nec_state->ip = info->i;							break;
 		case CPUINFO_INT_SP:
-			if( info->i - (Sreg(SS)<<4) < 0x10000 )
+			if( info->i - (Sreg(SS_)<<4) < 0x10000 )
 			{
-				Wreg(SP) = info->i - (Sreg(SS)<<4);
+				Wreg(SP) = info->i - (Sreg(SS_)<<4);
 			}
 			else
 			{
-				Sreg(SS) = info->i >> 4;
+				Sreg(SS_) = info->i >> 4;
 				Wreg(SP) = info->i & 0x0000f;
 			}
 			break;
@@ -565,7 +565,7 @@ static CPU_SET_INFO( nec )
 		case CPUINFO_INT_REGISTER + NEC_IY:				Wreg(IY) = info->i;					break;
 		case CPUINFO_INT_REGISTER + NEC_ES:				Sreg(DS1) = info->i;					break;
 		case CPUINFO_INT_REGISTER + NEC_CS:				Sreg(PS) = info->i;					break;
-		case CPUINFO_INT_REGISTER + NEC_SS:				Sreg(SS) = info->i;					break;
+		case CPUINFO_INT_REGISTER + NEC_SS:				Sreg(SS_) = info->i;					break;
 		case CPUINFO_INT_REGISTER + NEC_DS:				Sreg(DS0) = info->i;					break;
 	}
 }
@@ -614,7 +614,7 @@ static CPU_GET_INFO( nec )
 		case CPUINFO_INT_PC:
 		case CPUINFO_INT_REGISTER + NEC_PC:				info->i = ((Sreg(PS)<<4) + nec_state->ip);	break;
 		case CPUINFO_INT_REGISTER + NEC_IP:				info->i = nec_state->ip;							break;
-		case CPUINFO_INT_SP:							info->i = (Sreg(SS)<<4) + Wreg(SP); break;
+		case CPUINFO_INT_SP:							info->i = (Sreg(SS_)<<4) + Wreg(SP); break;
 		case CPUINFO_INT_REGISTER + NEC_SP:				info->i = Wreg(SP);					break;
 		case CPUINFO_INT_REGISTER + NEC_FLAGS:			info->i = CompressFlags();				break;
 		case CPUINFO_INT_REGISTER + NEC_AW:				info->i = Wreg(AW);					break;
@@ -626,7 +626,7 @@ static CPU_GET_INFO( nec )
 		case CPUINFO_INT_REGISTER + NEC_IY:				info->i = Wreg(IY);					break;
 		case CPUINFO_INT_REGISTER + NEC_ES:				info->i = Sreg(DS1);					break;
 		case CPUINFO_INT_REGISTER + NEC_CS:				info->i = Sreg(PS);					break;
-		case CPUINFO_INT_REGISTER + NEC_SS:				info->i = Sreg(SS);					break;
+		case CPUINFO_INT_REGISTER + NEC_SS:				info->i = Sreg(SS_);					break;
 		case CPUINFO_INT_REGISTER + NEC_DS:				info->i = Sreg(DS0);					break;
 		case CPUINFO_INT_REGISTER + NEC_PENDING:		info->i = nec_state->pending_irq;				break;
 
@@ -681,7 +681,7 @@ static CPU_GET_INFO( nec )
         case CPUINFO_STR_REGISTER + NEC_IY:				sprintf(info->s, "IY:%04X", Wreg(IY)); break;
         case CPUINFO_STR_REGISTER + NEC_ES:				sprintf(info->s, "DS1:%04X", Sreg(DS1)); break;
         case CPUINFO_STR_REGISTER + NEC_CS:				sprintf(info->s, "PS:%04X", Sreg(PS)); break;
-        case CPUINFO_STR_REGISTER + NEC_SS:				sprintf(info->s, "SS:%04X", Sreg(SS)); break;
+        case CPUINFO_STR_REGISTER + NEC_SS:				sprintf(info->s, "SS_:%04X", Sreg(SS_)); break;
         case CPUINFO_STR_REGISTER + NEC_DS:				sprintf(info->s, "DS0:%04X", Sreg(DS0)); break;
 	}
 }

--- a/src/cpu/nec/necea.h
+++ b/src/cpu/nec/necea.h
@@ -5,8 +5,8 @@ static UINT16 E16;
 
 static unsigned EA_000(nec_state_t *nec_state) { EO=Wreg(BW)+Wreg(IX); EA=DefaultBase(DS0)+EO; return EA; }
 static unsigned EA_001(nec_state_t *nec_state) { EO=Wreg(BW)+Wreg(IY); EA=DefaultBase(DS0)+EO; return EA; }
-static unsigned EA_002(nec_state_t *nec_state) { EO=Wreg(BP)+Wreg(IX); EA=DefaultBase(SS)+EO; return EA; }
-static unsigned EA_003(nec_state_t *nec_state) { EO=Wreg(BP)+Wreg(IY); EA=DefaultBase(SS)+EO; return EA; }
+static unsigned EA_002(nec_state_t *nec_state) { EO=Wreg(BP)+Wreg(IX); EA=DefaultBase(SS_)+EO; return EA; }
+static unsigned EA_003(nec_state_t *nec_state) { EO=Wreg(BP)+Wreg(IY); EA=DefaultBase(SS_)+EO; return EA; }
 static unsigned EA_004(nec_state_t *nec_state) { EO=Wreg(IX); EA=DefaultBase(DS0)+EO; return EA; }
 static unsigned EA_005(nec_state_t *nec_state) { EO=Wreg(IY); EA=DefaultBase(DS0)+EO; return EA; }
 static unsigned EA_006(nec_state_t *nec_state) { EO=FETCH(); EO+=FETCH()<<8; EA=DefaultBase(DS0)+EO; return EA; }
@@ -14,20 +14,20 @@ static unsigned EA_007(nec_state_t *nec_state) { EO=Wreg(BW); EA=DefaultBase(DS0
 
 static unsigned EA_100(nec_state_t *nec_state) { EO=(Wreg(BW)+Wreg(IX)+(INT8)FETCH()); EA=DefaultBase(DS0)+EO; return EA; }
 static unsigned EA_101(nec_state_t *nec_state) { EO=(Wreg(BW)+Wreg(IY)+(INT8)FETCH()); EA=DefaultBase(DS0)+EO; return EA; }
-static unsigned EA_102(nec_state_t *nec_state) { EO=(Wreg(BP)+Wreg(IX)+(INT8)FETCH()); EA=DefaultBase(SS)+EO; return EA; }
-static unsigned EA_103(nec_state_t *nec_state) { EO=(Wreg(BP)+Wreg(IY)+(INT8)FETCH()); EA=DefaultBase(SS)+EO; return EA; }
+static unsigned EA_102(nec_state_t *nec_state) { EO=(Wreg(BP)+Wreg(IX)+(INT8)FETCH()); EA=DefaultBase(SS_)+EO; return EA; }
+static unsigned EA_103(nec_state_t *nec_state) { EO=(Wreg(BP)+Wreg(IY)+(INT8)FETCH()); EA=DefaultBase(SS_)+EO; return EA; }
 static unsigned EA_104(nec_state_t *nec_state) { EO=(Wreg(IX)+(INT8)FETCH()); EA=DefaultBase(DS0)+EO; return EA; }
 static unsigned EA_105(nec_state_t *nec_state) { EO=(Wreg(IY)+(INT8)FETCH()); EA=DefaultBase(DS0)+EO; return EA; }
-static unsigned EA_106(nec_state_t *nec_state) { EO=(Wreg(BP)+(INT8)FETCH()); EA=DefaultBase(SS)+EO; return EA; }
+static unsigned EA_106(nec_state_t *nec_state) { EO=(Wreg(BP)+(INT8)FETCH()); EA=DefaultBase(SS_)+EO; return EA; }
 static unsigned EA_107(nec_state_t *nec_state) { EO=(Wreg(BW)+(INT8)FETCH()); EA=DefaultBase(DS0)+EO; return EA; }
 
 static unsigned EA_200(nec_state_t *nec_state) { E16=FETCH(); E16+=FETCH()<<8; EO=Wreg(BW)+Wreg(IX)+(INT16)E16; EA=DefaultBase(DS0)+EO; return EA; }
 static unsigned EA_201(nec_state_t *nec_state) { E16=FETCH(); E16+=FETCH()<<8; EO=Wreg(BW)+Wreg(IY)+(INT16)E16; EA=DefaultBase(DS0)+EO; return EA; }
-static unsigned EA_202(nec_state_t *nec_state) { E16=FETCH(); E16+=FETCH()<<8; EO=Wreg(BP)+Wreg(IX)+(INT16)E16; EA=DefaultBase(SS)+EO; return EA; }
-static unsigned EA_203(nec_state_t *nec_state) { E16=FETCH(); E16+=FETCH()<<8; EO=Wreg(BP)+Wreg(IY)+(INT16)E16; EA=DefaultBase(SS)+EO; return EA; }
+static unsigned EA_202(nec_state_t *nec_state) { E16=FETCH(); E16+=FETCH()<<8; EO=Wreg(BP)+Wreg(IX)+(INT16)E16; EA=DefaultBase(SS_)+EO; return EA; }
+static unsigned EA_203(nec_state_t *nec_state) { E16=FETCH(); E16+=FETCH()<<8; EO=Wreg(BP)+Wreg(IY)+(INT16)E16; EA=DefaultBase(SS_)+EO; return EA; }
 static unsigned EA_204(nec_state_t *nec_state) { E16=FETCH(); E16+=FETCH()<<8; EO=Wreg(IX)+(INT16)E16; EA=DefaultBase(DS0)+EO; return EA; }
 static unsigned EA_205(nec_state_t *nec_state) { E16=FETCH(); E16+=FETCH()<<8; EO=Wreg(IY)+(INT16)E16; EA=DefaultBase(DS0)+EO; return EA; }
-static unsigned EA_206(nec_state_t *nec_state) { E16=FETCH(); E16+=FETCH()<<8; EO=Wreg(BP)+(INT16)E16; EA=DefaultBase(SS)+EO; return EA; }
+static unsigned EA_206(nec_state_t *nec_state) { E16=FETCH(); E16+=FETCH()<<8; EO=Wreg(BP)+(INT16)E16; EA=DefaultBase(SS_)+EO; return EA; }
 static unsigned EA_207(nec_state_t *nec_state) { E16=FETCH(); E16+=FETCH()<<8; EO=Wreg(BW)+(INT16)E16; EA=DefaultBase(DS0)+EO; return EA; }
 
 static unsigned (*const GetEA[192])(nec_state_t *)={

--- a/src/cpu/nec/necinstr.c
+++ b/src/cpu/nec/necinstr.c
@@ -58,8 +58,8 @@ OP( 0x12, i_adc_r8b  ) { DEF_r8b;	src+=CF;	ADDB;	RegByte(ModRM)=dst;			CLKM(2,2,
 OP( 0x13, i_adc_r16w ) { DEF_r16w;	src+=CF;	ADDW;	RegWord(ModRM)=dst;			CLKR(15,15,8,15,11,6,2,EA);	}
 OP( 0x14, i_adc_ald8 ) { DEF_ald8;	src+=CF;	ADDB;	Breg(AL)=dst;			CLKS(4,4,2);				}
 OP( 0x15, i_adc_axd16) { DEF_axd16;	src+=CF;	ADDW;	Wreg(AW)=dst;			CLKS(4,4,2);				}
-OP( 0x16, i_push_ss  ) { PUSH(Sreg(SS));		CLKS(12,8,3);	}
-OP( 0x17, i_pop_ss   ) { POP(Sreg(SS));		CLKS(12,8,5);	nec_state->no_interrupt=1; }
+OP( 0x16, i_push_ss  ) { PUSH(Sreg(SS_));		CLKS(12,8,3);	}
+OP( 0x17, i_pop_ss   ) { POP(Sreg(SS_));		CLKS(12,8,5);	nec_state->no_interrupt=1; }
 
 OP( 0x18, i_sbb_br8  ) { DEF_br8;	src+=CF;	SUBB;	PutbackRMByte(ModRM,dst);	CLKM(2,2,2,16,16,7);		}
 OP( 0x19, i_sbb_wr16 ) { DEF_wr16;	src+=CF;	SUBW;	PutbackRMWord(ModRM,dst);	CLKR(24,24,11,24,16,7,2,EA);}
@@ -94,7 +94,7 @@ OP( 0x32, i_xor_r8b  ) { DEF_r8b;	XORB;	RegByte(ModRM)=dst;			CLKM(2,2,2,11,11,6
 OP( 0x33, i_xor_r16w ) { DEF_r16w;	XORW;	RegWord(ModRM)=dst;			CLKR(15,15,8,15,11,6,2,EA);	}
 OP( 0x34, i_xor_ald8 ) { DEF_ald8;	XORB;	Breg(AL)=dst;			CLKS(4,4,2);				}
 OP( 0x35, i_xor_axd16) { DEF_axd16;	XORW;	Wreg(AW)=dst;			CLKS(4,4,2);	}
-OP( 0x36, i_ss       ) { nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(SS)<<4;	CLK(2);		nec_instruction[fetchop(nec_state)](nec_state);	nec_state->seg_prefix=FALSE; }
+OP( 0x36, i_ss       ) { nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(SS_)<<4;	CLK(2);		nec_instruction[fetchop(nec_state)](nec_state);	nec_state->seg_prefix=FALSE; }
 OP( 0x37, i_aaa      ) { ADJB(6, (Breg(AL) > 0xf9) ? 2 : 1);		CLKS(7,7,4);	}
 
 OP( 0x38, i_cmp_br8  ) { DEF_br8;	SUBB;					CLKM(2,2,2,11,11,6); }
@@ -182,7 +182,7 @@ OP( 0x64, i_repnc  ) {	UINT32 next = fetchop(nec_state);	UINT16 c = Wreg(CW);
 	switch(next) { /* Segments */
 		case 0x26:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(DS1)<<4;	next = fetchop(nec_state);	CLK(2); break;
 		case 0x2e:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(PS)<<4;	next = fetchop(nec_state);	CLK(2); break;
-		case 0x36:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(SS)<<4;	next = fetchop(nec_state);	CLK(2); break;
+		case 0x36:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(SS_)<<4;	next = fetchop(nec_state);	CLK(2); break;
 		case 0x3e:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(DS0)<<4;	next = fetchop(nec_state);	CLK(2); break;
 	}
 
@@ -210,7 +210,7 @@ OP( 0x65, i_repc  ) {	UINT32 next = fetchop(nec_state);	UINT16 c = Wreg(CW);
 	switch(next) { /* Segments */
 		case 0x26:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(DS1)<<4;	next = fetchop(nec_state);	CLK(2); break;
 		case 0x2e:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(PS)<<4;	next = fetchop(nec_state);	CLK(2); break;
-		case 0x36:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(SS)<<4;	next = fetchop(nec_state);	CLK(2); break;
+		case 0x36:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(SS_)<<4;	next = fetchop(nec_state);	CLK(2); break;
 		case 0x3e:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(DS0)<<4;	next = fetchop(nec_state);	CLK(2); break;
 	}
 
@@ -329,7 +329,7 @@ OP( 0x8c, i_mov_wsreg ) { GetModRM;
 	switch (ModRM & 0x38) {
 		case 0x00: PutRMWord(ModRM,Sreg(DS1)); CLKR(14,14,5,14,10,3,2,EA); break;
 		case 0x08: PutRMWord(ModRM,Sreg(PS)); CLKR(14,14,5,14,10,3,2,EA); break;
-		case 0x10: PutRMWord(ModRM,Sreg(SS)); CLKR(14,14,5,14,10,3,2,EA); break;
+		case 0x10: PutRMWord(ModRM,Sreg(SS_)); CLKR(14,14,5,14,10,3,2,EA); break;
 		case 0x18: PutRMWord(ModRM,Sreg(DS0)); CLKR(14,14,5,14,10,3,2,EA); break;
 //		default:   logerror("%06x: MOV Sreg - Invalid register\n",PC(nec_state));
 	}
@@ -339,7 +339,7 @@ OP( 0x8e, i_mov_sregw ) { UINT16 src; GetModRM; src = GetRMWord(ModRM); CLKR(15,
 	switch (ModRM & 0x38) {
 		case 0x00: Sreg(DS1) = src; break; /* mov es,ew */
 		case 0x08: Sreg(PS) = src; break; /* mov cs,ew */
-		case 0x10: Sreg(SS) = src; break; /* mov ss,ew */
+		case 0x10: Sreg(SS_) = src; break; /* mov ss,ew */
 		case 0x18: Sreg(DS0) = src; break; /* mov ds,ew */
 //		default:   logerror("%06x: MOV Sreg - Invalid register\n",PC(nec_state));
 	}
@@ -452,7 +452,7 @@ OP( 0xc8, i_enter ) {
 	Wreg(BP)=Wreg(SP);
 	Wreg(SP) -= nb;
 	for (i=1;i<level;i++) {
-		PUSH(GetMemW(SS,Wreg(BP)-i*2));
+		PUSH(GetMemW(SS_,Wreg(BP)-i*2));
 		nec_state->icount-=16;
 	}
 	if (level) PUSH(Wreg(BP));
@@ -560,7 +560,7 @@ OP( 0xf2, i_repne    ) { UINT32 next = fetchop(nec_state); UINT16 c = Wreg(CW);
 	switch(next) { /* Segments */
 		case 0x26:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(DS1)<<4;	next = fetchop(nec_state);	CLK(2); break;
 		case 0x2e:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(PS)<<4;		next = fetchop(nec_state);	CLK(2); break;
-		case 0x36:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(SS)<<4;		next = fetchop(nec_state);	CLK(2); break;
+		case 0x36:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(SS_)<<4;		next = fetchop(nec_state);	CLK(2); break;
 		case 0x3e:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(DS0)<<4;	next = fetchop(nec_state);	CLK(2); break;
 	}
 
@@ -587,7 +587,7 @@ OP( 0xf3, i_repe     ) { UINT32 next = fetchop(nec_state); UINT16 c = Wreg(CW);
 	switch(next) { /* Segments */
 		case 0x26:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(DS1)<<4;	next = fetchop(nec_state);	CLK(2); break;
 		case 0x2e:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(PS)<<4;	next = fetchop(nec_state);	CLK(2); break;
-		case 0x36:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(SS)<<4;	next = fetchop(nec_state);	CLK(2); break;
+		case 0x36:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(SS_)<<4;	next = fetchop(nec_state);	CLK(2); break;
 		case 0x3e:	nec_state->seg_prefix=TRUE;	nec_state->prefix_base=Sreg(DS0)<<4;	next = fetchop(nec_state);	CLK(2); break;
 	}
 

--- a/src/cpu/nec/necpriv.h
+++ b/src/cpu/nec/necpriv.h
@@ -74,7 +74,8 @@ struct _nec_state_t
 	INT8	stop_run;
 };
 
-typedef enum { DS1, PS, SS, DS0 } SREGS;
+// SS seems to be reserved on Solaris, renaming to SS_ everywhere
+typedef enum { DS1, PS, SS_, DS0 } SREGS;
 typedef enum { AW, CW, DW, BW, SP, BP, IX, IY } WREGS;
 
 #ifdef LSB_FIRST
@@ -132,7 +133,7 @@ typedef enum {
 
 #define SegBase(Seg) (Sreg(Seg) << 4)
 
-#define DefaultBase(Seg) ((nec_state->seg_prefix && (Seg==DS0 || Seg==SS)) ? nec_state->prefix_base : Sreg(Seg) << 4)
+#define DefaultBase(Seg) ((nec_state->seg_prefix && (Seg==DS0 || Seg==SS_)) ? nec_state->prefix_base : Sreg(Seg) << 4)
 
 #define GetMemB(Seg,Off) (read_mem_byte(DefaultBase(Seg) + (Off)))
 #define GetMemW(Seg,Off) (read_mem_word(DefaultBase(Seg) + (Off)))
@@ -148,8 +149,8 @@ typedef enum {
 #define EMPTY_PREFETCH()	nec_state->prefetch_reset = 1
 
 
-#define PUSH(val) { Wreg(SP) -= 2; write_mem_word(((Sreg(SS)<<4)+Wreg(SP)), val); }
-#define POP(var) { Wreg(SP) += 2; var = read_mem_word(((Sreg(SS)<<4) + ((Wreg(SP)-2) & 0xffff))); }
+#define PUSH(val) { Wreg(SP) -= 2; write_mem_word(((Sreg(SS_)<<4)+Wreg(SP)), val); }
+#define POP(var) { Wreg(SP) += 2; var = read_mem_word(((Sreg(SS_)<<4) + ((Wreg(SP)-2) & 0xffff))); }
 
 
 #define GetModRM UINT32 ModRM=FETCH()

--- a/src/cpu/nec/v25.cpp
+++ b/src/cpu/nec/v25.cpp
@@ -231,7 +231,7 @@ int v25_reset()
 
 	SetRB(7);
 	Sreg(PS) = 0xffff;
-	Sreg(SS) = 0;
+	Sreg(SS_) = 0;
 	Sreg(DS0) = 0;
 	Sreg(DS1) = 0;
 
@@ -667,13 +667,13 @@ static CPU_SET_INFO( v25 )
 			break;
 		case CPUINFO_INT_REGISTER + NEC_IP:				nec_state->ip = info->i;							break;
 		case CPUINFO_INT_SP:
-			if( info->i - (Sreg(SS)<<4) < 0x10000 )
+			if( info->i - (Sreg(SS_)<<4) < 0x10000 )
 			{
-				Wreg(SP) = info->i - (Sreg(SS)<<4);
+				Wreg(SP) = info->i - (Sreg(SS_)<<4);
 			}
 			else
 			{
-				Sreg(SS) = info->i >> 4;
+				Sreg(SS_) = info->i >> 4;
 				Wreg(SP) = info->i & 0x0000f;
 			}
 			break;
@@ -688,7 +688,7 @@ static CPU_SET_INFO( v25 )
 		case CPUINFO_INT_REGISTER + NEC_IY:				Wreg(IY) = info->i;					break;
 		case CPUINFO_INT_REGISTER + NEC_ES:				Sreg(DS1) = info->i;					break;
 		case CPUINFO_INT_REGISTER + NEC_CS:				Sreg(PS) = info->i;					break;
-		case CPUINFO_INT_REGISTER + NEC_SS:				Sreg(SS) = info->i;					break;
+		case CPUINFO_INT_REGISTER + NEC_SS:				Sreg(SS_) = info->i;					break;
 		case CPUINFO_INT_REGISTER + NEC_DS:				Sreg(DS0) = info->i;					break;
 	}
 }
@@ -740,7 +740,7 @@ static CPU_GET_INFO( v25v35 )
 		case CPUINFO_INT_PC:
 		case CPUINFO_INT_REGISTER + NEC_PC:				info->i = ((Sreg(PS)<<4) + nec_state->ip);	break;
 		case CPUINFO_INT_REGISTER + NEC_IP:				info->i = nec_state->ip;							break;
-		case CPUINFO_INT_SP:							info->i = (Sreg(SS)<<4) + Wreg(SP); break;
+		case CPUINFO_INT_SP:							info->i = (Sreg(SS_)<<4) + Wreg(SP); break;
 		case CPUINFO_INT_REGISTER + NEC_SP:				info->i = Wreg(SP);					break;
 		case CPUINFO_INT_REGISTER + NEC_FLAGS:			info->i = CompressFlags();				break;
 		case CPUINFO_INT_REGISTER + NEC_AW:				info->i = Wreg(AW);					break;
@@ -752,7 +752,7 @@ static CPU_GET_INFO( v25v35 )
 		case CPUINFO_INT_REGISTER + NEC_IY:				info->i = Wreg(IY);					break;
 		case CPUINFO_INT_REGISTER + NEC_ES:				info->i = Sreg(DS1);					break;
 		case CPUINFO_INT_REGISTER + NEC_CS:				info->i = Sreg(PS);					break;
-		case CPUINFO_INT_REGISTER + NEC_SS:				info->i = Sreg(SS);					break;
+		case CPUINFO_INT_REGISTER + NEC_SS:				info->i = Sreg(SS_);					break;
 		case CPUINFO_INT_REGISTER + NEC_DS:				info->i = Sreg(DS0);					break;
 		case CPUINFO_INT_REGISTER + NEC_PENDING:		info->i = nec_state->pending_irq;				break;
 
@@ -805,7 +805,7 @@ static CPU_GET_INFO( v25v35 )
         case CPUINFO_STR_REGISTER + NEC_IY:				sprintf(info->s, "IY:%04X", Wreg(IY)); break;
         case CPUINFO_STR_REGISTER + NEC_ES:				sprintf(info->s, "DS1:%04X", Sreg(DS1)); break;
         case CPUINFO_STR_REGISTER + NEC_CS:				sprintf(info->s, "PS:%04X", Sreg(PS)); break;
-        case CPUINFO_STR_REGISTER + NEC_SS:				sprintf(info->s, "SS:%04X", Sreg(SS)); break;
+        case CPUINFO_STR_REGISTER + NEC_SS:				sprintf(info->s, "SS_:%04X", Sreg(SS_)); break;
         case CPUINFO_STR_REGISTER + NEC_DS:				sprintf(info->s, "DS0:%04X", Sreg(DS0)); break;
 	}
 }

--- a/src/cpu/nec/v25instr.c
+++ b/src/cpu/nec/v25instr.c
@@ -23,12 +23,12 @@
 
 #define MOVSPA	\
 	tmp = (Wreg(PSW_SAVE) & 0x7000) >> 8;	\
-	Sreg(SS) = nec_state->ram.w[tmp+SS];	\
+	Sreg(SS_) = nec_state->ram.w[tmp+SS_];	\
 	Wreg(SP) = nec_state->ram.w[tmp+SP]
 
 #define MOVSPB	\
 	tmp <<= 4;	\
-	nec_state->ram.w[tmp+SS] = Sreg(SS);	\
+	nec_state->ram.w[tmp+SS_] = Sreg(SS_);	\
 	nec_state->ram.w[tmp+SP] = Wreg(SP)
 
 #define FINT	\

--- a/src/cpu/nec/v25priv.h
+++ b/src/cpu/nec/v25priv.h
@@ -137,7 +137,7 @@ enum {
 typedef enum {
 	DS1 = 0x0E/2,
 	PS  = 0x0C/2,
-	SS  = 0x0A/2,
+	SS_  = 0x0A/2,
 	DS0 = 0x08/2
 } SREGS;
 
@@ -215,7 +215,7 @@ void v25_write_word(v25_state_t *nec_state, unsigned a, UINT16 d);
 
 #define SegBase(Seg) (Sreg(Seg) << 4)
 
-#define DefaultBase(Seg) ((nec_state->seg_prefix && (Seg==DS0 || Seg==SS)) ? nec_state->prefix_base : Sreg(Seg) << 4)
+#define DefaultBase(Seg) ((nec_state->seg_prefix && (Seg==DS0 || Seg==SS_)) ? nec_state->prefix_base : Sreg(Seg) << 4)
 
 #define GetMemB(Seg,Off) (read_mem_byte(DefaultBase(Seg) + (Off)))
 #define GetMemW(Seg,Off) (read_mem_word(DefaultBase(Seg) + (Off)))
@@ -230,8 +230,8 @@ void v25_write_word(v25_state_t *nec_state, unsigned a, UINT16 d);
 #define EMPTY_PREFETCH()	nec_state->prefetch_reset = 1
 
 
-#define PUSH(val) { Wreg(SP) -= 2; write_mem_word(((Sreg(SS)<<4)+Wreg(SP)), val); }
-#define POP(var) { Wreg(SP) += 2; var = read_mem_word(((Sreg(SS)<<4) + ((Wreg(SP)-2) & 0xffff))); }
+#define PUSH(val) { Wreg(SP) -= 2; write_mem_word(((Sreg(SS_)<<4)+Wreg(SP)), val); }
+#define POP(var) { Wreg(SP) += 2; var = read_mem_word(((Sreg(SS_)<<4) + ((Wreg(SP)-2) & 0xffff))); }
 
 #define GetModRM UINT32 ModRM=FETCH()
 


### PR DESCRIPTION
Seems like SS is reserved on Solaris, breaking the build. 
Renaming it to SS_ fixes the issue, even though it may not be the most elegant solution.