### PR TITLE
Test

### DIFF
--- a/src/burn/drv/irem/d_m107.cpp
+++ b/src/burn/drv/irem/d_m107.cpp
@@ -989,7 +989,7 @@ static INT32 DrvDraw()
 			DrvPalette[i] = CalcCol(i<<1);
 		bRecalcPalette = 0;
 	}
-//	DrawLayers(0, nScreenHeight);
+	DrawLayers(0, nScreenHeight);
 
 	if (nBurnLayer & 8) draw_sprites();
 
@@ -1023,7 +1023,7 @@ static void scanline_interrupts(INT32 scanline)
 
 		if (scanline>=8 && scanline < 248 && nPrevScreenPos != (scanline-8)+1) {
 			if (nPrevScreenPos >= 0 && nPrevScreenPos <= 239)
-				DrawLayers(nPrevScreenPos, (scanline-8)+1);
+			//	DrawLayers(nPrevScreenPos, (scanline-8)+1);
 			nPrevScreenPos = (scanline-8)+1;
 		}
 
@@ -1037,7 +1037,7 @@ static void scanline_interrupts(INT32 scanline)
 		vblank = 0;
 
 		if (nPrevScreenPos != 240) {
-			DrawLayers(nPrevScreenPos, 240);
+		//	DrawLayers(nPrevScreenPos, 240);
 		}
 		nPrevScreenPos = 0;
 


### PR DESCRIPTION
Scanlines can be flipped off to net a significant performance boost in the M92 / M107 drivers
dont merge these changes as it's just to let you try it out sometime.