### PR TITLE
add libretro cheat memory support for more systems

### DIFF
--- a/src/burn/drv/capcom/cps_mem.cpp
+++ b/src/burn/drv/capcom/cps_mem.cpp
@@ -14,8 +14,6 @@ static UINT8 *CpsSaveRegData = NULL;
 static UINT8 *CpsSaveFrgData = NULL;
 UINT8 *CpsRam660=NULL,*CpsRam708=NULL,*CpsReg=NULL,*CpsFrg=NULL;
 UINT8 *CpsRamFF=NULL;
-UINT8 *CpsRamAll=NULL;
-UINT32 CpsRamAllSize=0;
 
 CpsMemScanCallback CpsMemScanCallbackFunction = NULL;
 
@@ -25,7 +23,6 @@ static INT32 CpsMemIndex()
 {
 	UINT8*  Next; Next =  CpsMem;
 
-	CpsRamAll         = CpsMem ;
 	CpsRam90	  = Next; Next += 0x030000;							// Video Ram
 	CpsRamFF	  = Next; Next += 0x010000;							// Work Ram
 	CpsReg		  = Next; Next += 0x000100;							// Registers
@@ -78,7 +75,6 @@ static INT32 AllocateMemory()
 	}
 
 	memset(CpsMem, 0, nLen);										// blank all memory
-	CpsRamAllSize = nLen ;
 	CpsMemIndex();													// Index the allocated memory
 
 	return 0;
@@ -353,7 +349,7 @@ INT32 CpsMemExit()
 	return 0;
 }
 
-static INT32 ScanRam(INT32 includeAllPtr)
+static INT32 ScanRam()
 {
 	// scan ram:
 	struct BurnArea ba;
@@ -371,11 +367,6 @@ static INT32 ScanRam(INT32 includeAllPtr)
 	if (Cps == 2) {
 		ba.Data = CpsRam708;  ba.nLen = 0x010000; ba.szName = "CpsRam708"; BurnAcb(&ba);
 		ba.Data = CpsFrg;     ba.nLen = 0x000010; ba.szName = "CpsFrg";    BurnAcb(&ba);
-		ba.Data = CpsRam660;  ba.nLen = 0x004000; ba.szName = "CpsRam660"; BurnAcb(&ba);
-	}
-
-	if ( includeAllPtr == 1 ) {
-		ba.Data = CpsRamAll;  ba.nLen = CpsRamAllSize; ba.szName = "CpsRamAll";    BurnAcb(&ba);
 	}
 
 	return 0;
@@ -414,7 +405,16 @@ INT32 CpsAreaScan(INT32 nAction, INT32 *pnMin)
 	}
 
 	if (nAction & ACB_MEMORY_RAM) {
-		ScanRam(nAction == ACB_MEMORY_RAM ? 1 : 0); //if nAction is exactly equal to ACB_MEMORY_RAM then we know this is just to search for memory pointers and is not for save states
+
+		ScanRam(); 
+
+		if (Cps == 2) {
+			memset(&ba, 0, sizeof(ba));
+			ba.Data   = CpsRam660;
+			ba.nLen   = 0x004000;
+			ba.szName = "CpsRam660";
+			BurnAcb(&ba);
+		}
 	}
 
 

--- a/src/burn/drv/capcom/cps_mem.cpp
+++ b/src/burn/drv/capcom/cps_mem.cpp
@@ -14,6 +14,8 @@ static UINT8 *CpsSaveRegData = NULL;
 static UINT8 *CpsSaveFrgData = NULL;
 UINT8 *CpsRam660=NULL,*CpsRam708=NULL,*CpsReg=NULL,*CpsFrg=NULL;
 UINT8 *CpsRamFF=NULL;
+UINT8 *CpsRamAll=NULL;
+UINT32 CpsRamAllSize=0;
 
 CpsMemScanCallback CpsMemScanCallbackFunction = NULL;
 
@@ -23,6 +25,7 @@ static INT32 CpsMemIndex()
 {
 	UINT8*  Next; Next =  CpsMem;
 
+	CpsRamAll         = CpsMem ;
 	CpsRam90	  = Next; Next += 0x030000;							// Video Ram
 	CpsRamFF	  = Next; Next += 0x010000;							// Work Ram
 	CpsReg		  = Next; Next += 0x000100;							// Registers
@@ -75,6 +78,7 @@ static INT32 AllocateMemory()
 	}
 
 	memset(CpsMem, 0, nLen);										// blank all memory
+	CpsRamAllSize = nLen ;
 	CpsMemIndex();													// Index the allocated memory
 
 	return 0;
@@ -365,9 +369,12 @@ static INT32 ScanRam()
 	}
 
 	if (Cps == 2) {
-		ba.Data = CpsRam708; ba.nLen = 0x010000; ba.szName = "CpsRam708"; BurnAcb(&ba);
-		ba.Data = CpsFrg;    ba.nLen = 0x000010; ba.szName = "CpsFrg";    BurnAcb(&ba);
+		ba.Data = CpsRam708;  ba.nLen = 0x010000; ba.szName = "CpsRam708"; BurnAcb(&ba);
+		ba.Data = CpsFrg;     ba.nLen = 0x000010; ba.szName = "CpsFrg";    BurnAcb(&ba);
+		ba.Data = CpsRam660;  ba.nLen = 0x004000; ba.szName = "CpsRam660"; BurnAcb(&ba);
 	}
+
+	ba.Data = CpsRamAll;  ba.nLen = CpsRamAllSize; ba.szName = "CpsRamAll";    BurnAcb(&ba);
 
 	return 0;
 }
@@ -408,13 +415,6 @@ INT32 CpsAreaScan(INT32 nAction, INT32 *pnMin)
 
 		ScanRam();
 
-		if (Cps == 2) {
-			memset(&ba, 0, sizeof(ba));
-			ba.Data   = CpsRam660;
-			ba.nLen   = 0x004000;
-			ba.szName = "CpsRam660";
-			BurnAcb(&ba);
-		}
 	}
 
 

--- a/src/burn/drv/capcom/cps_mem.cpp
+++ b/src/burn/drv/capcom/cps_mem.cpp
@@ -353,7 +353,7 @@ INT32 CpsMemExit()
 	return 0;
 }
 
-static INT32 ScanRam()
+static INT32 ScanRam(INT32 includeAllPtr)
 {
 	// scan ram:
 	struct BurnArea ba;
@@ -374,7 +374,9 @@ static INT32 ScanRam()
 		ba.Data = CpsRam660;  ba.nLen = 0x004000; ba.szName = "CpsRam660"; BurnAcb(&ba);
 	}
 
-	ba.Data = CpsRamAll;  ba.nLen = CpsRamAllSize; ba.szName = "CpsRamAll";    BurnAcb(&ba);
+	if ( includeAllPtr == 1 ) {
+		ba.Data = CpsRamAll;  ba.nLen = CpsRamAllSize; ba.szName = "CpsRamAll";    BurnAcb(&ba);
+	}
 
 	return 0;
 }
@@ -412,9 +414,7 @@ INT32 CpsAreaScan(INT32 nAction, INT32 *pnMin)
 	}
 
 	if (nAction & ACB_MEMORY_RAM) {
-
-		ScanRam();
-
+		ScanRam(nAction == ACB_MEMORY_RAM ? 1 : 0); //if nAction is exactly equal to ACB_MEMORY_RAM then we know this is just to search for memory pointers and is not for save states
 	}
 
 

--- a/src/burner/libretro/retro_mem.cpp
+++ b/src/burner/libretro/retro_mem.cpp
@@ -22,7 +22,7 @@ int StateGetMainRamAcb(BurnArea *pba)
 	if ((nHardwareCode & HARDWARE_PUBLIC_MASK) == HARDWARE_CAPCOM_CPS1
 	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) == HARDWARE_CAPCOM_CPS1_QSOUND
 	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) == HARDWARE_CAPCOM_CPS2) {
-		if (strcmp(pba->szName, "CpsRamFF") == 0) {
+		if (strcmp(pba->szName, "CpsRamAll") == 0) {
 			MainRamData = pba->Data;
 			MainRamSize = pba->nLen;
 			bMainRamFound = true;

--- a/src/burner/libretro/retro_mem.cpp
+++ b/src/burner/libretro/retro_mem.cpp
@@ -37,13 +37,66 @@ int StateGetMainRamAcb(BurnArea *pba)
 			bMainRamFound = true;
 		}
 	}
-	if ((nHardwareCode & HARDWARE_PUBLIC_MASK) == HARDWARE_PREFIX_KONAMI) {
+	if ((nHardwareCode & HARDWARE_PUBLIC_MASK) == HARDWARE_PREFIX_KONAMI
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_PREFIX_TAITO
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_PREFIX_IREM
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_PREFIX_DATAEAST
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_PREFIX_PACMAN
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_PREFIX_CAPCOM_MISC
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_PREFIX_GALAXIAN
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_PREFIX_SETA
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_PREFIX_TECHNOS
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_PREFIX_PCENGINE
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_SEGA_SYSTEMX
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_SEGA_SYSTEMY
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_SEGA_SYSTEM16A
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_SEGA_SYSTEM16B
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_SEGA_SYSTEM16M
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_SEGA_SYSTEM18
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_SEGA_HANGON
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_SEGA_OUTRUN
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_SEGA_SYSTEM1
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_SEGA_MISC
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_PREFIX_TOAPLAN) {
 		if (strcmp(pba->szName, "All Ram") == 0) {
 			MainRamData = pba->Data;
 			MainRamSize = pba->nLen;
 			bMainRamFound = true;
 		}
 	}
+
+
+
+	if ((nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_PREFIX_CAVE) {
+		if (strcmp(pba->szName, "RAM") == 0) {
+			MainRamData = pba->Data;
+			MainRamSize = pba->nLen;
+			bMainRamFound = true;
+		}
+	}
+	if ((nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_PREFIX_IGS_PGM) {
+		if (strcmp(pba->szName, "Z80 RAM") == 0) {
+			MainRamData = pba->Data;
+			MainRamSize = pba->nLen;
+			bMainRamFound = true;
+		}
+	}
+	if ((nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_PREFIX_PSIKYO) {
+		if (strcmp(pba->szName, "68K RAM") == 0) {
+			MainRamData = pba->Data;
+			MainRamSize = pba->nLen;
+			bMainRamFound = true;
+		}
+	}
+	if ((nHardwareCode & HARDWARE_PUBLIC_MASK) & HARDWARE_PREFIX_KANEKO) {
+		if ( (strcmp(pba->szName, "All Ram") == 0) || (strcmp(pba->szName, "All RAM") == 0) ) {
+			MainRamData = pba->Data;
+			MainRamSize = pba->nLen;
+			bMainRamFound = true;
+		}
+	}
+
+
 
 	return 0;
 }

--- a/src/burner/libretro/retro_mem.cpp
+++ b/src/burner/libretro/retro_mem.cpp
@@ -21,8 +21,10 @@ int StateGetMainRamAcb(BurnArea *pba)
 	}
 	if ((nHardwareCode & HARDWARE_PUBLIC_MASK) == HARDWARE_CAPCOM_CPS1
 	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) == HARDWARE_CAPCOM_CPS1_QSOUND
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) == HARDWARE_CAPCOM_CPS1_GENERIC
+	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) == HARDWARE_CAPCOM_CPSCHANGER
 	 || (nHardwareCode & HARDWARE_PUBLIC_MASK) == HARDWARE_CAPCOM_CPS2) {
-		if (strcmp(pba->szName, "CpsRamAll") == 0) {
+		if (strcmp(pba->szName, "CpsRamFF") == 0) {
 			MainRamData = pba->Data;
 			MainRamSize = pba->nLen;
 			bMainRamFound = true;
@@ -35,6 +37,14 @@ int StateGetMainRamAcb(BurnArea *pba)
 			bMainRamFound = true;
 		}
 	}
+	if ((nHardwareCode & HARDWARE_PUBLIC_MASK) == HARDWARE_PREFIX_KONAMI) {
+		if (strcmp(pba->szName, "All Ram") == 0) {
+			MainRamData = pba->Data;
+			MainRamSize = pba->nLen;
+			bMainRamFound = true;
+		}
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
I went through burn.h for all of the HARDWARE_PREFIX defines - this should be nearly everything now.  The only thing I didn't go through were some of the individual systems like SMS/SNES since there are lots of other emulators for those systems