### PR TITLE
Updated and cleaned up A7A7

### DIFF
--- a/makefile.libretro
+++ b/makefile.libretro
@@ -267,20 +267,10 @@ else ifeq ($(platform), classic_armv7_a7)
 	TARGET := $(TARGET_NAME)_libretro.so
 	fpic := -fPIC
 	SHARED := -shared -Wl,-no-undefined -Wl,--version-script=$(VERSION_SCRIPT)
-	# There is already stuff for -Ox below, if Ofast is safe for fbalpha,
-	# it needs to be properly tested and added for all platforms
-	# PLATFORM_FLAGS += -Ofast
+	# Ofast safe for this platform and tested. Maybe can be tested on other platforms
+	PLATFORM_FLAGS += -Ofast
 	PLATFORM_FLAGS = -marm -mtune=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
-	# The following c++11 stuff makes no sense, fbalpha is gnu99/gnu++98 compliant
-	# it was probably just overriding a faulty flag above
-	# CXXFLAGS := -std=gnu++11
-	# CFLAGS := -std=gnu11
-	# The following is definitely unneeded
-	# BUILTIN_GPU = neon
-	# USE_DYNAREC = 1
-	# CPPFLAGS += $(CFLAGS)
-	# ASFLAGS += $(CFLAGS)
-	USE_EXPERIMENTAL_FLAGS = 1
+	A7A7_FLAGS = 1
 	HAVE_NEON = 1
 	ARCH = arm
 	ENDIANNESS_DEFINES := -DLSB_FIRST
@@ -471,7 +461,8 @@ ifeq ($(FASTMATH), 1)
    endif
 endif
 
-ifeq ($(USE_EXPERIMENTAL_FLAGS), 1)
+#Armv7 Cortex A7 build flags. (Intended for Classic Systems)
+ifeq ($(A7A7_FLAGS), 1) 
 	EXPERIMENTAL_FLAGS = -flto=4 -fwhole-program -fuse-linker-plugin \
 		-fdata-sections -ffunction-sections -Wl,--gc-sections \
 		-fno-stack-protector -fno-ident -fomit-frame-pointer \


### PR DESCRIPTION
Hi @barbudreadmon,

I cleaned up based on your recommendations. I made a couple of small adjustments on your cleanup
1. I added Ofast back in for the A7A7 platform as it builds and runs perfectly fine with the Classics and has been tested for quite a while in the past. I did add a note that maybe this can be tested on other platforms.
2. I changed USE_EXPERIMENTAL_FLAGS to A7A7_FLAGS as these aren't particularly experimental but more specific to the Armv7CortexA7 platform. We are anticipating a new classic soon which should be CortexA9 so the flags will be adjusted slightly for A7A9. I felt the word EXPERIMENTAL didn't quite line up.

This should be the final revision for a while until we add another sub platform under the classic banner.